### PR TITLE
feat: add light/dark mode toggle with customized dark theme styling

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useDark, useToggle } from '@vueuse/core';
 import { useModal } from '@/composables/useModal';
 import { useListModal } from '@/composables/useListModal';
 import { useLists } from '@/composables/useLists';
@@ -7,6 +8,16 @@ import ListCard from '@/components/ListCard.vue';
 import ModalDialogue from '@/components/ModalDialogue.vue';
 import AddListCard from '@/components/AddListCard.vue';
 import ListModalDialogue from './components/ListModalDialogue.vue';
+
+// Initialize dark mode composables
+// const isDark = useDark(); // reactive variable for dark mode status
+const isDark = useDark({
+  selector: 'body', // Apply dark mode to the body instead of html
+  attribute: 'color-scheme', // Custom attribute name
+  valueDark: 'dark', // Dark mode attribute value
+  valueLight: 'light' // Light mode attribute value
+});
+const toggleDark = useToggle(isDark); // toggle function for switching modes
 
 const { lists } = useLists();
 const { isModalOpen, editingCard, modalMode, openModal, closeModal, saveCard, deleteCard } =
@@ -24,7 +35,13 @@ const {
 </script>
 
 <template>
-  <main class="p-5 font-sans">
+  <main :class="{ dark: isDark }" class="p-5 font-sans">
+    <button
+      @click="() => toggleDark()"
+      class="mode-button mb-5 px-4 py-2 rounded-md border text-xl hover:bg-gray-100 active:translate-y-2 transition-transform"
+    >
+      {{ isDark ? '☀️ Light Mode' : '🌙 Dark Mode' }}
+    </button>
     <div class="flex gap-5 py-5 overflow-x-auto">
       <Draggable v-model="lists" group="lists" item-key="id" class="flex gap-5 cursor-pointer">
         <template #item="{ element, index }">
@@ -34,11 +51,12 @@ const {
             :listIndex="index"
             :openModal="openModal"
             @show-modal="editList"
+            class="list-card"
           />
         </template>
       </Draggable>
 
-      <AddListCard @show-modal="showListModal" />
+      <AddListCard @show-modal="showListModal" class="add-list-card" />
     </div>
 
     <ModalDialogue
@@ -61,3 +79,42 @@ const {
     />
   </main>
 </template>
+
+<style>
+/* Default dark mode for body-based configuration */
+
+body[color-scheme='dark'] {
+  background-color: #1b2431;
+}
+
+body[color-scheme='dark'] .list-card,
+body[color-scheme='dark'] .add-list-card {
+  background-color: #273142;
+}
+
+body[color-scheme='dark'] .task-card {
+  background-color: #374151;
+  color: #f3f4f6;
+}
+
+body[color-scheme='dark'] button {
+  background-color: #374151;
+  color: #f3f4f6;
+  border: none;
+}
+
+body[color-scheme='dark'] button:hover {
+  color: #1b2431;
+}
+
+body[color-scheme='dark'] .mode-button {
+  color: #f3f4f6;
+}
+
+body[color-scheme='dark'] .mode-button:hover {
+  color: #1b2431;
+  background-color: #f3f4f6;
+}
+
+/* Add other custom dark/light mode styles as needed */
+</style>

--- a/src/components/TaskCard.vue
+++ b/src/components/TaskCard.vue
@@ -48,7 +48,7 @@ function getTextColor(backgroundColor: string) {
 
 <template>
   <div
-    class="bg-white p-2 my-2 rounded shadow cursor-pointer hover:translate-y-[-3px] transform transition-transform"
+    class="task-card bg-white p-2 my-2 rounded shadow cursor-pointer hover:translate-y-[-3px] transform transition-transform"
     @click="$emit('click')"
   >
     <div class="flex justify-between">


### PR DESCRIPTION
- Integrated 'vueuse/core's 'useDark' and 'useToggle' for light/dark mode toggle functionality. See [VueUse useDark documentation](https://vueuse.org/core/useDark/).
- Added a toggle button in App.vue with icons for light ☀️ and dark 🌙 modes, providing an intuitive switch for users.
- Customized dark mode styles for 'ListCard', 'AddListCard', and 'TaskCard' components with distinct color schemes.
- Applied dark mode-specific styles to 'body' to control background color, button styling, and hover effects for a seamless theme transition.
- Structured the CSS to enable scalable dark mode customization for future elements.

This update enhances the user experience with a cohesive, responsive dark theme.